### PR TITLE
Caches the status of the NDT e2e test 

### DIFF
--- a/ndt_e2e.sh
+++ b/ndt_e2e.sh
@@ -53,7 +53,8 @@ if ! /sbin/tc filter show dev eth0 | grep -q $HEX_IP; then
 fi
 
 # Do a queueing check first.
-STATUS=$(nodejs $NDT_JS --quiet --queueingtest --server $HOST)
+OUTPUT=$(nodejs $NDT_JS --quiet --queueingtest --server $HOST)
+STATUS=$?
 
 # If the server isn't queueing, then run the e2e test.
 if [[ "$STATUS" -ne "$STATE_QUEUEING" ]]; then


### PR DESCRIPTION
The script will now return the cached result if the cached value is less than some threshold (currently 600s). This PR is complementary to m-lab/prometheus-support#187.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-script-exporter/6)
<!-- Reviewable:end -->
