### PR TITLE
Fetches script_exporter from the m-lab Github account

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN git clone https://github.com/m-lab/operator.git /opt/mlab/operator
 RUN git clone https://github.com/m-lab/ndt.git /opt/mlab/ndt
 
 # Fetch and build script_exporter
-RUN GOPATH=/root/go go get github.com/nkinkade/script_exporter
+RUN GOPATH=/root/go go get github.com/m-lab/script_exporter
 
 # Copy scripts and configs
 COPY apply_tc_rules.sh /bin/apply_tc_rules.sh


### PR DESCRIPTION
This was previously being pulled from the fork in my personal Github account. Since it seems unlikely that the PR I submitted upstream will ever get attention, it made more sense to move my fork to the m-lab account.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-script-exporter/7)
<!-- Reviewable:end -->
