### PR TITLE
Sets Docker containers to always restart + upgrades machine type for mlab-oti deployment

### DIFF
--- a/deploy_script_exporter.sh
+++ b/deploy_script_exporter.sh
@@ -26,7 +26,7 @@ GCE_IMG_FAMILY="coreos-stable"
 # instance machine types to account for expected load.
 case $PROJECT in
   mlab-oti)
-    MACHINE_TYPE="n1-highmem-4"
+    MACHINE_TYPE="n1-standard-8"
     ;;
   mlab-staging)
     MACHINE_TYPE="n1-standard-2"

--- a/deploy_script_exporter.sh
+++ b/deploy_script_exporter.sh
@@ -85,7 +85,7 @@ gcloud compute scp $SCP_FILES $GCE_NAME:~
 gcloud compute ssh $GCE_NAME --command "docker build -t ${IMAGE_TAG} ."
 
 # Start a new container based on the new/updated image.
-gcloud compute ssh $GCE_NAME --command "docker run --cap-add NET_ADMIN -p 9172:9172 -d ${IMAGE_TAG}"
+gcloud compute ssh $GCE_NAME --command "docker run --cap-add NET_ADMIN --publish 9172:9172 --detach --restart always ${IMAGE_TAG}"
 
 # Run Prometheus node_exporter in a container so we can gather VM metrics.
-gcloud compute ssh $GCE_NAME --command "docker run --detach --publish 9100:9100 --volume /proc:/host/proc --volume /sys:/host/sys prom/node-exporter --path.procfs /host/proc --path.sysfs /host/sys --no-collector.arp --no-collector.bcache --no-collector.conntrack --no-collector.edac --no-collector.entropy --no-collector.filefd --no-collector.hwmon --no-collector.infiniband --no-collector.ipvs --no-collector.mdadm --no-collector.netstat --no-collector.sockstat --no-collector.time --no-collector.timex --no-collector.uname --no-collector.vmstat --no-collector.wifi --no-collector.xfs --no-collector.zfs"
+gcloud compute ssh $GCE_NAME --command "docker run --detach --publish 9100:9100 --volume /proc:/host/proc --volume /sys:/host/sys --restart always prom/node-exporter --path.procfs /host/proc --path.sysfs /host/sys --no-collector.arp --no-collector.bcache --no-collector.conntrack --no-collector.edac --no-collector.entropy --no-collector.filefd --no-collector.hwmon --no-collector.infiniband --no-collector.ipvs --no-collector.mdadm --no-collector.netstat --no-collector.sockstat --no-collector.time --no-collector.timex --no-collector.uname --no-collector.vmstat --no-collector.wifi --no-collector.xfs --no-collector.zfs"

--- a/deploy_script_exporter.sh
+++ b/deploy_script_exporter.sh
@@ -85,7 +85,7 @@ gcloud compute scp $SCP_FILES $GCE_NAME:~
 gcloud compute ssh $GCE_NAME --command "docker build -t ${IMAGE_TAG} ."
 
 # Start a new container based on the new/updated image.
-gcloud compute ssh $GCE_NAME --command "docker run --cap-add NET_ADMIN --publish 9172:9172 --detach --restart always ${IMAGE_TAG}"
+gcloud compute ssh $GCE_NAME --command "docker run --detach --restart always --publish 9172:9172 --cap-add NET_ADMIN ${IMAGE_TAG}"
 
 # Run Prometheus node_exporter in a container so we can gather VM metrics.
-gcloud compute ssh $GCE_NAME --command "docker run --detach --publish 9100:9100 --volume /proc:/host/proc --volume /sys:/host/sys --restart always prom/node-exporter --path.procfs /host/proc --path.sysfs /host/sys --no-collector.arp --no-collector.bcache --no-collector.conntrack --no-collector.edac --no-collector.entropy --no-collector.filefd --no-collector.hwmon --no-collector.infiniband --no-collector.ipvs --no-collector.mdadm --no-collector.netstat --no-collector.sockstat --no-collector.time --no-collector.timex --no-collector.uname --no-collector.vmstat --no-collector.wifi --no-collector.xfs --no-collector.zfs"
+gcloud compute ssh $GCE_NAME --command "docker run --detach --restart always --publish 9100:9100 --volume /proc:/host/proc --volume /sys:/host/sys prom/node-exporter --path.procfs /host/proc --path.sysfs /host/sys --no-collector.arp --no-collector.bcache --no-collector.conntrack --no-collector.edac --no-collector.entropy --no-collector.filefd --no-collector.hwmon --no-collector.infiniband --no-collector.ipvs --no-collector.mdadm --no-collector.netstat --no-collector.sockstat --no-collector.time --no-collector.timex --no-collector.uname --no-collector.vmstat --no-collector.wifi --no-collector.xfs --no-collector.zfs"


### PR DESCRIPTION
Currently, if the GCE instance running the script_exporter gets restarted for any reason, the Docker containers are not automatically started. This PR adds the `--restart=always` flag to the `docker-run` commands so that containerd always restarts the containers.

This PR also bumps the GCE machine type for the mlab-oti project to n1-standard-8, since the other other was running out of memory and CPU.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-script-exporter/9)
<!-- Reviewable:end -->
