### PR TITLE
Sets the mtime of the e2e cache file to now()-random

### DIFF
--- a/ndt_e2e.sh
+++ b/ndt_e2e.sh
@@ -19,6 +19,11 @@ STATE_CRITICAL=2
 STATE_UNKNOWN=3
 STATE_QUEUEING=5
 
+# Flags whether this is the first time an e2e test has been run against this
+# node since this VM has been running. See comment later in this script to
+# understand why this variable exists.
+FIRST_RUN=false
+
 NDT_JS=/opt/mlab/ndt/src/node_tests/ndt_client.js
 
 if [ -n "$1" ]; then
@@ -78,7 +83,7 @@ echo $STATUS > $CACHE_DIR/$HOST
 # statuses to expire at randomly different times and spread the NDT e2e test
 # load across the entire expiration interval.
 if [[ $FIRST_RUN ]]; then
-    RAND=$(shuf -i 1-$MAX_CACHE_AGE -n 1)
+    RAND=$(($RANDOM % $MAX_CACHE_AGE))
     touch --date "${RAND} seconds ago" $CACHE_DIR/$HOST
 fi
 


### PR DESCRIPTION
Currently, Prometheus probes the script_exporter every 60 seconds. There are a lot of nodes (~400) to probe in that time. This means that `ndt_e2e.sh` gets run for all these nodes in a very short period of time, which loads the VM heavily. `ndt_e2e.sh` caches return codes for the test for 10 minutes, in the case that the test was successful. What this ultimately means is that all the cached results expire around the same time, which causes another spike in ndt_e2e test volume. This plays out as a cyclic spike and fall in resource usage every $MAX_CACHE_AGE interval.

To help avoid these huge spikes and spread out the load, this PR sets the mtime of the cache file (the first time it is created) into the past somewhere between 1s and $MAX_CACHE_AGEs. In this way, the cached results should expire at randomly different times, which will spread out the actual e2e testing randomly in the expiry interval.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-script-exporter/10)
<!-- Reviewable:end -->
