### PR TITLE
Sets up a daily cron job to update the tc traffic shaping rules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
 FROM debian:stretch-slim
 
 # Install necessary packages
-RUN apt-get update -qq
-RUN apt-get install -qq apt-transport-https curl dnsutils git gnupg golang iproute2 python sudo
+RUN apt-get update -qq && apt-get install -qq apt-transport-https curl dnsutils git gnupg golang iproute2 python sudo
 
 # Setup Node.js repository, install nodejs, and any needed modules
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 RUN echo "deb https://deb.nodesource.com/node_0.12 jessie main" > /etc/apt/sources.list.d/nodesource.list
-RUN apt-get update -qq
-RUN apt-get install -qq nodejs=0.12.18-1nodesource1~jessie1
+RUN apt-get update -qq && apt-get install -qq nodejs=0.12.18-1nodesource1~jessie1
 RUN npm install --global --quiet minimist@1.2.0 ws@1.0.1
 
 # Clone necessary git repos
@@ -20,6 +18,7 @@ RUN GOPATH=/root/go go get github.com/m-lab/script_exporter
 
 # Copy scripts and configs
 COPY apply_tc_rules.sh /bin/apply_tc_rules.sh
+COPY apply_tc_rules.cron /etc/cron.d/
 COPY ndt_e2e.sh /bin/ndt_e2e.sh
 COPY script_exporter.yml /etc/script_exporter/config.yml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:stretch-slim
 
 # Install necessary packages
-RUN apt-get update -qq && apt-get install -qq apt-transport-https curl dnsutils git gnupg golang iproute2 python sudo
+RUN apt-get update -qq && apt-get install -qq apt-transport-https cron curl dnsutils git gnupg golang iproute2 python sudo
 
 # Setup Node.js repository, install nodejs, and any needed modules
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN GOPATH=/root/go go get github.com/m-lab/script_exporter
 
 # Copy scripts and configs
 COPY apply_tc_rules.sh /bin/apply_tc_rules.sh
-COPY apply_tc_rules.cron /etc/cron.d/
+COPY apply_tc_rules.cron /etc/cron.daily/
 COPY ndt_e2e.sh /bin/ndt_e2e.sh
 COPY script_exporter.yml /etc/script_exporter/config.yml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,6 @@ COPY apply_tc_rules.cron /etc/cron.daily/apply_tc_rules
 COPY ndt_e2e.sh /bin/ndt_e2e.sh
 COPY script_exporter.yml /etc/script_exporter/config.yml
 
-# Launch script_exporter, first running apply_tc_rules.sh
+# First start cron, then run apply_tc_rules.sh, then script_exporter.
 EXPOSE 9172
-ENTRYPOINT /bin/apply_tc_rules.sh && /root/go/bin/script_exporter -config.file=/etc/script_exporter/config.yml
+ENTRYPOINT service cron start && bin/apply_tc_rules.sh && /root/go/bin/script_exporter -config.file=/etc/script_exporter/config.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN GOPATH=/root/go go get github.com/m-lab/script_exporter
 
 # Copy scripts and configs
 COPY apply_tc_rules.sh /bin/apply_tc_rules.sh
-COPY apply_tc_rules.cron /etc/cron.daily/
+COPY apply_tc_rules.cron /etc/cron.daily/apply_tc_rules
 COPY ndt_e2e.sh /bin/ndt_e2e.sh
 COPY script_exporter.yml /etc/script_exporter/config.yml
 

--- a/apply_tc_rules.cron
+++ b/apply_tc_rules.cron
@@ -1,5 +1,3 @@
-# Applies tc traffic limiting/filtering rules for the ndt_e2e.sh test.
+#!/bin/sh
 
-MAILTO=root
-
-@daily root /bin/apply_tc_rules.sh
+/bin/apply_tc_rules.sh

--- a/apply_tc_rules.cron
+++ b/apply_tc_rules.cron
@@ -1,0 +1,5 @@
+# Applies tc traffic limiting/filtering rules for the ndt_e2e.sh test.
+
+MAILTO=root
+
+@daily root /bin/apply_tc_rules.sh

--- a/deploy_script_exporter.sh
+++ b/deploy_script_exporter.sh
@@ -8,7 +8,7 @@ set -x
 USAGE="Usage: $0 <project> <keyname>"
 PROJECT=${1:?Please provide project name: $USAGE}
 KEYNAME=${2:?Please provide an authentication key name: $USAGE}
-SCP_FILES="apply_tc_rules.sh Dockerfile ndt_e2e.sh script_exporter.yml"
+SCP_FILES="apply_tc_rules.sh apply_tc_rules.cron Dockerfile ndt_e2e.sh script_exporter.yml"
 IMAGE_TAG="m-lab/prometheus-script-exporter"
 GCE_ZONE="us-central1-a"
 GCE_NAME="script-exporter"


### PR DESCRIPTION
This PR is to resolve this issue:

https://github.com/m-lab/ops-tracker/issues/345

The script ndt_e2e.sh will refuse to run for a host (IP address) that doesn't have tc traffic filtering configured.  When sites.py gets new sites, or IPs change, the tc rules need to change. This PR sets up a daily cron job that will update the tc rules to accommodate for any changes to sites.py.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-script-exporter/11)
<!-- Reviewable:end -->
