### PR TITLE
Removes cron from container in favor of using a systemd timer on the host VM.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:stretch-slim
 
 # Install necessary packages
-RUN apt-get update -qq && apt-get install -qq apt-transport-https cron curl dnsutils git gnupg golang iproute2 python sudo
+RUN apt-get update -qq && apt-get install -qq apt-transport-https curl dnsutils git gnupg golang iproute2 python sudo
 
 # Setup Node.js repository, install nodejs, and any needed modules
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
@@ -18,10 +18,9 @@ RUN GOPATH=/root/go go get github.com/m-lab/script_exporter
 
 # Copy scripts and configs
 COPY apply_tc_rules.sh /bin/apply_tc_rules.sh
-COPY apply_tc_rules.cron /etc/cron.daily/apply_tc_rules
 COPY ndt_e2e.sh /bin/ndt_e2e.sh
 COPY script_exporter.yml /etc/script_exporter/config.yml
 
-# First start cron, then run apply_tc_rules.sh, then script_exporter.
+# Run apply_tc_rules.sh, then script_exporter.
 EXPOSE 9172
-ENTRYPOINT service cron start && bin/apply_tc_rules.sh && /root/go/bin/script_exporter -config.file=/etc/script_exporter/config.yml
+ENTRYPOINT /bin/apply_tc_rules.sh && /root/go/bin/script_exporter -config.file=/etc/script_exporter/config.yml

--- a/apply_tc_rules.cron
+++ b/apply_tc_rules.cron
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-/bin/apply_tc_rules.sh

--- a/cloud-config.yml
+++ b/cloud-config.yml
@@ -1,5 +1,27 @@
 #cloud-config
 
+coreos:
+  units:
+    - name: apply-tc-rules.service
+      content: |
+        [Unit]
+        Description=Updates tc traffic shaping rules in the script-exporter container.
+
+        [Service]
+        Type=oneshot
+        ExecStart=/bin/docker exec -ti script-exporter /bin/apply_tc_rules.sh
+    - name: apply-tc-rules.timer
+      command: "start"
+      content: |
+        [Unit]
+        Description=Run apply-tc-rules.service daily.
+
+        [Timer]
+        OnCalendar=daily
+
+        [Install]
+        WantedBy=multi-user.target
+
 write_files:
   - path: /etc/ssh/sshd_config
     permissions: 0600
@@ -15,3 +37,4 @@ write_files:
       PasswordAuthentication no
       ChallengeResponseAuthentication no
       PermitRootLogin no
+

--- a/deploy_script_exporter.sh
+++ b/deploy_script_exporter.sh
@@ -8,7 +8,7 @@ set -x
 USAGE="Usage: $0 <project> <keyname>"
 PROJECT=${1:?Please provide project name: $USAGE}
 KEYNAME=${2:?Please provide an authentication key name: $USAGE}
-SCP_FILES="apply_tc_rules.sh apply_tc_rules.cron Dockerfile ndt_e2e.sh script_exporter.yml"
+SCP_FILES="apply_tc_rules.sh Dockerfile ndt_e2e.sh script_exporter.yml"
 IMAGE_TAG="m-lab/prometheus-script-exporter"
 GCE_ZONE="us-central1-a"
 GCE_NAME="script-exporter"
@@ -85,7 +85,7 @@ gcloud compute scp $SCP_FILES $GCE_NAME:~
 gcloud compute ssh $GCE_NAME --command "docker build -t ${IMAGE_TAG} ."
 
 # Start a new container based on the new/updated image.
-gcloud compute ssh $GCE_NAME --command "docker run --detach --restart always --publish 9172:9172 --cap-add NET_ADMIN ${IMAGE_TAG}"
+gcloud compute ssh $GCE_NAME --command "docker run --detach --restart always --publish 9172:9172 --name ${GCE_NAME} --cap-add NET_ADMIN ${IMAGE_TAG}"
 
 # Run Prometheus node_exporter in a container so we can gather VM metrics.
 gcloud compute ssh $GCE_NAME --command "docker run --detach --restart always --publish 9100:9100 --volume /proc:/host/proc --volume /sys:/host/sys prom/node-exporter --path.procfs /host/proc --path.sysfs /host/sys --no-collector.arp --no-collector.bcache --no-collector.conntrack --no-collector.edac --no-collector.entropy --no-collector.filefd --no-collector.hwmon --no-collector.infiniband --no-collector.ipvs --no-collector.mdadm --no-collector.netstat --no-collector.sockstat --no-collector.time --no-collector.timex --no-collector.uname --no-collector.vmstat --no-collector.wifi --no-collector.xfs --no-collector.zfs"


### PR DESCRIPTION
@pboothe reports that in his experience running cron in a Docker container is a bad idea. Also, something is half broken about the container as it is. This removes cron and the cron job from the container in favor of having the host VM use a systemd timer to update the tc traffic shaping rules in the script_exporter container every day.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-script-exporter/12)
<!-- Reviewable:end -->
