### PR TITLE
Increases the GCE machine type to n1-standard-8 for mlab-staging

### DIFF
--- a/deploy_script_exporter.sh
+++ b/deploy_script_exporter.sh
@@ -29,7 +29,7 @@ case $PROJECT in
     MACHINE_TYPE="n1-standard-8"
     ;;
   mlab-staging)
-    MACHINE_TYPE="n1-standard-2"
+    MACHINE_TYPE="n1-standard-8"
     ;;
   *)
     MACHINE_TYPE="n1-standard-1"


### PR DESCRIPTION
We are currently experiencing a memory issue on the script-exporter in mlab-staging; it runs out, invoking the oom-killer, taking down the Docker containers. Until we can figure out the root cause, this PR will up the memory substantially. This can likely be undone once we figure out why memory usage is spiking.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-script-exporter/16)
<!-- Reviewable:end -->
