### PR TITLE
Modifies ndt_e2e.sh script to run test using encryption on port 3010.

### DIFF
--- a/ndt_e2e.sh
+++ b/ndt_e2e.sh
@@ -64,12 +64,13 @@ if ! /sbin/tc filter show dev eth0 | grep -q $HEX_IP; then
 fi
 
 # Do a queueing check first.
-OUTPUT=$(nodejs $NDT_JS --quiet --queueingtest --server $HOST)
+OUTPUT=$(nodejs $NDT_JS --quiet --queueingtest --server $HOST --protocol wss \
+  --port 3010)
 STATUS=$?
 
 # If the server isn't queueing, then run the e2e test.
 if [[ "$STATUS" -ne "$STATE_QUEUEING" ]]; then
-    OUTPUT=$(nodejs $NDT_JS --quiet --server $HOST)
+    OUTPUT=$(nodejs $NDT_JS --quiet --server $HOST --protocol wss --port 3010)
     STATUS=$?
 fi
 


### PR DESCRIPTION
Currently, the test runs unencrypted on port 3001. This is fine, but is not representative of most of our traffic any longer. The bulk of our traffic is encrypted on port 3010, so one of our core availability tests should do the same.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/prometheus-script-exporter/17)
<!-- Reviewable:end -->
